### PR TITLE
[M4] Add UI for transcription progress (chunk-by-chunk)

### DIFF
--- a/src/features/transcription/components/TranscriptionProgress.module.css
+++ b/src/features/transcription/components/TranscriptionProgress.module.css
@@ -1,0 +1,61 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.status {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text, #1e293b);
+}
+
+.partial {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  background: var(--surface-raised, #f8fafc);
+  border-radius: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border, #e2e8f0);
+}
+
+.partialLabel {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted, #64748b);
+}
+
+.partialText {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--text, #1e293b);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Mobile-first: larger tap targets, more padding */
+@media (max-width: 600px) {
+  .container {
+    padding: 12px 8px;
+  }
+
+  .status {
+    font-size: 1.0625rem;
+  }
+
+  .partialText {
+    font-size: 1rem;
+  }
+}

--- a/src/features/transcription/components/TranscriptionProgress.test.tsx
+++ b/src/features/transcription/components/TranscriptionProgress.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TranscriptionProgress from './TranscriptionProgress';
+
+describe('TranscriptionProgress', () => {
+  it('renders chunk status label', () => {
+    render(<TranscriptionProgress currentChunk={3} totalChunks={8} />);
+    expect(screen.getByText('Transcribing chunk 3 of 8')).toBeDefined();
+  });
+
+  it('renders partial text when provided', () => {
+    render(
+      <TranscriptionProgress currentChunk={2} totalChunks={5} partialText="Hello world" />,
+    );
+    expect(screen.getByText('Hello world')).toBeDefined();
+  });
+
+  it('does not render partial text section when empty', () => {
+    const { container } = render(
+      <TranscriptionProgress currentChunk={1} totalChunks={4} />,
+    );
+    expect(container.querySelector('[aria-label="Partial transcription"]')).toBeNull();
+  });
+
+  it('clamps currentChunk to totalChunks', () => {
+    render(<TranscriptionProgress currentChunk={99} totalChunks={5} />);
+    expect(screen.getByText('Transcribing chunk 5 of 5')).toBeDefined();
+  });
+
+  it('uses indeterminate bar when currentChunk is 0', () => {
+    render(<TranscriptionProgress currentChunk={0} totalChunks={8} />);
+    // progress bar role exists
+    expect(screen.getByRole('progressbar')).toBeDefined();
+  });
+
+  it('has accessible section label', () => {
+    render(<TranscriptionProgress currentChunk={1} totalChunks={3} />);
+    expect(screen.getByRole('region', { name: 'Transcription progress' })).toBeDefined();
+  });
+});

--- a/src/features/transcription/components/TranscriptionProgress.test.tsx
+++ b/src/features/transcription/components/TranscriptionProgress.test.tsx
@@ -5,14 +5,14 @@ import TranscriptionProgress from './TranscriptionProgress';
 describe('TranscriptionProgress', () => {
   it('renders chunk status label', () => {
     render(<TranscriptionProgress currentChunk={3} totalChunks={8} />);
-    expect(screen.getByText('Transcribing chunk 3 of 8')).toBeDefined();
+    expect(screen.getByText('Transcribing chunk 3 of 8')).toBeInTheDocument();
   });
 
   it('renders partial text when provided', () => {
     render(
       <TranscriptionProgress currentChunk={2} totalChunks={5} partialText="Hello world" />,
     );
-    expect(screen.getByText('Hello world')).toBeDefined();
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   it('does not render partial text section when empty', () => {
@@ -24,17 +24,34 @@ describe('TranscriptionProgress', () => {
 
   it('clamps currentChunk to totalChunks', () => {
     render(<TranscriptionProgress currentChunk={99} totalChunks={5} />);
-    expect(screen.getByText('Transcribing chunk 5 of 5')).toBeDefined();
+    expect(screen.getByText('Transcribing chunk 5 of 5')).toBeInTheDocument();
+  });
+
+  it('clamps negative currentChunk to 0', () => {
+    render(<TranscriptionProgress currentChunk={-3} totalChunks={5} />);
+    expect(screen.getByText('Transcribing chunk 0 of 5')).toBeInTheDocument();
+  });
+
+  it('handles totalChunks=0 gracefully (treats as 1)', () => {
+    render(<TranscriptionProgress currentChunk={0} totalChunks={0} />);
+    expect(screen.getByText('Transcribing chunk 0 of 1')).toBeInTheDocument();
   });
 
   it('uses indeterminate bar when currentChunk is 0', () => {
     render(<TranscriptionProgress currentChunk={0} totalChunks={8} />);
-    // progress bar role exists
-    expect(screen.getByRole('progressbar')).toBeDefined();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
   it('has accessible section label', () => {
     render(<TranscriptionProgress currentChunk={1} totalChunks={3} />);
-    expect(screen.getByRole('region', { name: 'Transcription progress' })).toBeDefined();
+    expect(screen.getByRole('region', { name: 'Transcription progress' })).toBeInTheDocument();
+  });
+
+  it('partial text live region does not include static label', () => {
+    render(
+      <TranscriptionProgress currentChunk={1} totalChunks={3} partialText="Some text" />,
+    );
+    const liveRegion = screen.getByText('Some text');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
   });
 });

--- a/src/features/transcription/components/TranscriptionProgress.tsx
+++ b/src/features/transcription/components/TranscriptionProgress.tsx
@@ -17,13 +17,15 @@ export default function TranscriptionProgress({
   partialText = '',
 }: TranscriptionProgressProps) {
   const safeTotal = Math.max(1, totalChunks);
-  const safeCurrent = Math.min(currentChunk, safeTotal);
+  // Guard against negative values and clamp to valid range
+  const safeCurrent = Math.min(Math.max(0, currentChunk), safeTotal);
   const progress = safeCurrent / safeTotal;
   const label = `Transcribing chunk ${safeCurrent} of ${safeTotal}`;
 
   return (
     <section className={styles.container} aria-label="Transcription progress">
-      <p className={styles.status} aria-live="polite" aria-atomic="true">
+      {/* aria-live is omitted here — ProcessingProgressBar's internal live region handles announcements */}
+      <p className={styles.status}>
         {label}
       </p>
 
@@ -34,9 +36,12 @@ export default function TranscriptionProgress({
       />
 
       {partialText && (
-        <div className={styles.partial} aria-live="polite" aria-label="Partial transcription">
-          <p className={styles.partialLabel}>Partial result:</p>
-          <p className={styles.partialText}>{partialText}</p>
+        <div className={styles.partial} aria-label="Partial transcription">
+          {/* Static label kept outside the live region to avoid re-announcement on every update */}
+          <p className={styles.partialLabel} aria-hidden="true">Partial result:</p>
+          <p className={styles.partialText} aria-live="polite" aria-atomic="false">
+            {partialText}
+          </p>
         </div>
       )}
     </section>

--- a/src/features/transcription/components/TranscriptionProgress.tsx
+++ b/src/features/transcription/components/TranscriptionProgress.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ProcessingProgressBar from '../../../shared/components/ProcessingProgressBar';
+import styles from './TranscriptionProgress.module.css';
+
+export interface TranscriptionProgressProps {
+  /** Index of the chunk currently being transcribed (0-based) */
+  currentChunk: number;
+  /** Total number of chunks */
+  totalChunks: number;
+  /** Partial transcription text accumulated so far */
+  partialText?: string;
+}
+
+export default function TranscriptionProgress({
+  currentChunk,
+  totalChunks,
+  partialText = '',
+}: TranscriptionProgressProps) {
+  const safeTotal = Math.max(1, totalChunks);
+  const safeCurrent = Math.min(currentChunk, safeTotal);
+  const progress = safeCurrent / safeTotal;
+  const label = `Transcribing chunk ${safeCurrent} of ${safeTotal}`;
+
+  return (
+    <section className={styles.container} aria-label="Transcription progress">
+      <p className={styles.status} aria-live="polite" aria-atomic="true">
+        {label}
+      </p>
+
+      <ProcessingProgressBar
+        value={progress}
+        label={label}
+        indeterminate={safeCurrent === 0}
+      />
+
+      {partialText && (
+        <div className={styles.partial} aria-live="polite" aria-label="Partial transcription">
+          <p className={styles.partialLabel}>Partial result:</p>
+          <p className={styles.partialText}>{partialText}</p>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Working as artist

Implements TranscriptionProgress component for issue #14.

## Changes
- `src/features/transcription/components/TranscriptionProgress.tsx` - component showing chunk N of total and partial text
- `TranscriptionProgress.module.css` - mobile-first styles, scrollable partial text area
- `TranscriptionProgress.test.tsx` - unit tests for label, partial text, clamping, a11y

## Acceptance criteria
- [x] TranscriptionProgress.tsx component created
- [x] Shows current chunk number and total
- [x] Displays partial transcription text as chunks complete
- [x] Reuses ProcessingProgressBar for chunk-level progress
- [x] Mobile-friendly layout with scrollable text
- [x] ARIA live regions for real-time screen reader updates

Closes #14

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
