### PR TITLE
[M4] Handle transcription errors and retries

### DIFF
--- a/ISSUE_15_REVIEW_PR_53.md
+++ b/ISSUE_15_REVIEW_PR_53.md
@@ -1,0 +1,31 @@
+Reviewer: PR #53 — CHANGES REQUESTED
+
+Summary:
+- Status: CHANGES REQUESTED (see details below)
+
+Findings:
+1) Loading state during retries
+- Code (src/features/transcription/useTranscriptionWithRetry.ts) sets loading=true before the retry loop and keeps it true on each retry, only setting loading=false on success or final failure. Behavior is correct, but tests do not assert this.
+
+2) Internal error logging
+- Code calls console.error('transcribeAudio error:', err) inside the catch. Logging exists, but tests do not assert console.error was called.
+
+3) Tests and timers
+- Tests use fake timers (vi.useFakeTimers()) and advance timers; they assert call counts for squadService.run (toHaveBeenCalledTimes 2 and 3). This passes the "use fake timers and assert call counts" requirement.
+
+4) Human names
+- Repository contains human names in documentation files: .copilot/skills/ci-validation-gates/SKILL.md (Drucker, Trejo). The production code and tests for this PR do not include human names, but the repo-level presence violates the "no human names present" rule if it applies globally.
+
+5) Test execution
+- I attempted to run the test suite but the environment failed: npm test errored with a Node/npm environment issue.
+  Error: Cannot find module 'C:\\Users\\quique.fernandez\\AppData\\Local\\Volta\\tools\\image\\npm\\11.10.0\\bin\\node_modules\\npm\\bin\\npm-prefix.js' (Node v22.17.0)
+
+Requested changes:
+- Add assertions to tests to verify state.loading remains true while retries are happening (e.g., spy on state or expose interim state, or assert immediately after first failure before advancing timers).
+- Spy on console.error in the tests and assert it is called when internal errors occur.
+- If the repository policy forbids human names anywhere, remove or anonymize names from the docs (.copilot/skills/*). If the rule only applies to test/code, no change required.
+- Re-run tests in a healthy Node/npm environment; CI should validate there are no environment issues.
+
+Conclusion: CHANGES REQUESTED — tests need explicit assertions for loading and console.error, and document-level human names should be removed if the rule is global.
+
+Reviewer agent: automated reviewer

--- a/src/features/transcription/TranscriptionErrorBanner.module.css
+++ b/src/features/transcription/TranscriptionErrorBanner.module.css
@@ -1,0 +1,15 @@
+.banner{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  background: #fff1f2;
+  border: 1px solid #fecaca;
+  padding: 10px 12px;
+  border-radius:8px;
+}
+
+.message{ color:#b91c1c; font-weight:600; }
+.controls{ display:flex; gap:8px; align-items:center; }
+.retry{ background:#1f2937; color:#fff; border:none; padding:6px 10px; border-radius:6px; cursor:pointer; }
+.permanent{ color:#6b7280; }

--- a/src/features/transcription/TranscriptionErrorBanner.tsx
+++ b/src/features/transcription/TranscriptionErrorBanner.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styles from './TranscriptionErrorBanner.module.css';
+
+export interface TranscriptionErrorBannerProps {
+  message: string;
+  onRetry: () => void;
+  attempts: number;
+  maxAttempts?: number;
+}
+
+export default function TranscriptionErrorBanner({ message, onRetry, attempts, maxAttempts = 3 }: TranscriptionErrorBannerProps) {
+  const permanent = attempts >= maxAttempts;
+
+  return (
+    <div className={styles.banner} role="alert" aria-live="assertive">
+      <div className={styles.message}>{message}</div>
+      <div className={styles.controls}>
+        {permanent ? (
+          <div className={styles.permanent}>Please try again later.</div>
+        ) : (
+          <button className={styles.retry} onClick={onRetry}>
+            Retry ({attempts}/{maxAttempts})
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/transcription/__tests__/useTranscriptionWithRetry.console.test.ts
+++ b/src/features/transcription/__tests__/useTranscriptionWithRetry.console.test.ts
@@ -1,0 +1,27 @@
+import { vi, describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as squad from '../../shared/squad/squadService';
+import { useTranscriptionWithRetry } from '../useTranscriptionWithRetry';
+
+vi.mock('../../shared/squad/squadService');
+
+describe('useTranscriptionWithRetry console logging', () => {
+  it('logs internal errors via console.error during retries', async () => {
+    const mockRun = (squad.squadService.run as any);
+    mockRun.mockImplementation(async () => { throw new Error('fatal'); });
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useTranscriptionWithRetry());
+
+    await act(async () => {
+      const p = result.current.transcribe(new ArrayBuffer(8));
+      // advance through retry delays
+      vi.advanceTimersByTime(3000);
+      await expect(p).rejects.toThrow();
+    });
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/src/features/transcription/__tests__/useTranscriptionWithRetry.test.ts
+++ b/src/features/transcription/__tests__/useTranscriptionWithRetry.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react-hooks';
 import * as squad from '../../shared/squad/squadService';
 import { useTranscriptionWithRetry } from '../useTranscriptionWithRetry';
@@ -6,6 +6,16 @@ import { useTranscriptionWithRetry } from '../useTranscriptionWithRetry';
 vi.mock('../../shared/squad/squadService');
 
 describe('useTranscriptionWithRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
   it('retries on failure and succeeds', async () => {
     const mockRun = (squad.squadService.run as any);
     let calls = 0;
@@ -18,11 +28,15 @@ describe('useTranscriptionWithRetry', () => {
     const { result } = renderHook(() => useTranscriptionWithRetry());
 
     await act(async () => {
-      const res = await result.current.transcribe(new ArrayBuffer(8));
+      const promise = result.current.transcribe(new ArrayBuffer(8));
+      // advance timers to allow retry delay
+      vi.advanceTimersByTime(1000);
+      const res = await promise;
       expect(res.text).toBe('ok');
     });
 
-    expect(calls).toBe(2);
+    expect(mockRun).toHaveBeenCalledTimes(2);
+    expect(result.current.state.attempts).toBe(2);
   });
 
   it('fails after max attempts', async () => {
@@ -32,7 +46,13 @@ describe('useTranscriptionWithRetry', () => {
     const { result } = renderHook(() => useTranscriptionWithRetry());
 
     await act(async () => {
-      await expect(result.current.transcribe(new ArrayBuffer(8))).rejects.toThrow();
+      const p = result.current.transcribe(new ArrayBuffer(8));
+      // advance through all retry delays (3 attempts => 2 delays)
+      vi.advanceTimersByTime(3000);
+      await expect(p).rejects.toThrow();
     });
+
+    expect(mockRun).toHaveBeenCalledTimes(3);
+    expect(result.current.state.attempts).toBe(3);
   });
 });

--- a/src/features/transcription/__tests__/useTranscriptionWithRetry.test.ts
+++ b/src/features/transcription/__tests__/useTranscriptionWithRetry.test.ts
@@ -29,10 +29,16 @@ describe('useTranscriptionWithRetry', () => {
 
     await act(async () => {
       const promise = result.current.transcribe(new ArrayBuffer(8));
+      // loading should be true immediately
+      expect(result.current.state.loading).toBe(true);
+
       // advance timers to allow retry delay
       vi.advanceTimersByTime(1000);
       const res = await promise;
       expect(res.text).toBe('ok');
+
+      // after success loading becomes false
+      expect(result.current.state.loading).toBe(false);
     });
 
     expect(mockRun).toHaveBeenCalledTimes(2);

--- a/src/features/transcription/__tests__/useTranscriptionWithRetry.test.ts
+++ b/src/features/transcription/__tests__/useTranscriptionWithRetry.test.ts
@@ -1,0 +1,38 @@
+import { vi, describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as squad from '../../shared/squad/squadService';
+import { useTranscriptionWithRetry } from '../useTranscriptionWithRetry';
+
+vi.mock('../../shared/squad/squadService');
+
+describe('useTranscriptionWithRetry', () => {
+  it('retries on failure and succeeds', async () => {
+    const mockRun = (squad.squadService.run as any);
+    let calls = 0;
+    mockRun.mockImplementation(async () => {
+      calls += 1;
+      if (calls < 2) throw new Error('runtime');
+      return { text: 'ok' };
+    });
+
+    const { result } = renderHook(() => useTranscriptionWithRetry());
+
+    await act(async () => {
+      const res = await result.current.transcribe(new ArrayBuffer(8));
+      expect(res.text).toBe('ok');
+    });
+
+    expect(calls).toBe(2);
+  });
+
+  it('fails after max attempts', async () => {
+    const mockRun = (squad.squadService.run as any);
+    mockRun.mockImplementation(async () => { throw new Error('fatal'); });
+
+    const { result } = renderHook(() => useTranscriptionWithRetry());
+
+    await act(async () => {
+      await expect(result.current.transcribe(new ArrayBuffer(8))).rejects.toThrow();
+    });
+  });
+});

--- a/src/features/transcription/useTranscriptionWithRetry.ts
+++ b/src/features/transcription/useTranscriptionWithRetry.ts
@@ -11,11 +11,13 @@ export type TranscriptionState = {
 export function useTranscriptionWithRetry() {
   const [state, setState] = useState<TranscriptionState>({ loading: false, attempts: 0, result: null });
 
-  const transcribe = useCallback(async (audioBuffer: ArrayBuffer) => {
-    setState({ loading: true, attempts: 0, result: null, error: null });
+  const transcribe = useCallback(async (audioBuffer: ArrayBuffer, opts?: { maxAttempts?: number; retryDelayMs?: number }) => {
+    const maxAttempts = opts?.maxAttempts ?? 3;
+    const retryDelayMs = opts?.retryDelayMs ?? 800;
+
+    setState(prev => ({ ...prev, loading: true, attempts: 0, result: null, error: null }));
 
     let attempts = 0;
-    const maxAttempts = 3;
 
     while (attempts < maxAttempts) {
       try {
@@ -25,19 +27,24 @@ export function useTranscriptionWithRetry() {
         return res;
       } catch (err: any) {
         const isOffline = !navigator.onLine;
-        const msg = isOffline
+        // Keep a friendly user message while logging the raw error for debugging
+        const userMsg = isOffline
           ? 'Device appears offline. Check your connection and retry.'
-          : (err?.message ?? 'Transcription failed due to an unexpected error.');
+          : 'Transcription failed. We attempted to retry automatically.';
 
-        setState({ loading: false, attempts, result: null, error: msg });
+        // Log the internal error for debugging (local console/storage)
+        try { console.error('transcribeAudio error:', err); } catch (_) {}
+
+        setState({ loading: true, attempts, result: null, error: userMsg });
 
         if (attempts >= maxAttempts) {
-          // permanent failure
-          return Promise.reject(new Error(msg));
+          // permanent failure — set loading false and reject
+          setState({ loading: false, attempts, result: null, error: userMsg });
+          return Promise.reject(new Error(userMsg));
         }
 
-        // wait briefly before retrying
-        await new Promise(r => setTimeout(r, 800));
+        // wait before retrying
+        await new Promise(r => setTimeout(r, retryDelayMs));
       }
     }
   }, []);

--- a/src/features/transcription/useTranscriptionWithRetry.ts
+++ b/src/features/transcription/useTranscriptionWithRetry.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from 'react';
+import { squadService } from '../../shared/squad/squadService';
+
+export type TranscriptionState = {
+  loading: boolean;
+  error?: string | null;
+  attempts: number;
+  result?: { text: string; language?: string; durationMs?: number } | null;
+};
+
+export function useTranscriptionWithRetry() {
+  const [state, setState] = useState<TranscriptionState>({ loading: false, attempts: 0, result: null });
+
+  const transcribe = useCallback(async (audioBuffer: ArrayBuffer) => {
+    setState({ loading: true, attempts: 0, result: null, error: null });
+
+    let attempts = 0;
+    const maxAttempts = 3;
+
+    while (attempts < maxAttempts) {
+      try {
+        attempts += 1;
+        const res = await squadService.run('transcribeAudio', { audioBuffer });
+        setState({ loading: false, attempts, result: res, error: null });
+        return res;
+      } catch (err: any) {
+        const isOffline = !navigator.onLine;
+        const msg = isOffline
+          ? 'Device appears offline. Check your connection and retry.'
+          : (err?.message ?? 'Transcription failed due to an unexpected error.');
+
+        setState({ loading: false, attempts, result: null, error: msg });
+
+        if (attempts >= maxAttempts) {
+          // permanent failure
+          return Promise.reject(new Error(msg));
+        }
+
+        // wait briefly before retrying
+        await new Promise(r => setTimeout(r, 800));
+      }
+    }
+  }, []);
+
+  const retry = useCallback((audioBuffer: ArrayBuffer) => {
+    return transcribe(audioBuffer);
+  }, [transcribe]);
+
+  return { state, transcribe, retry };
+}

--- a/src/features/transcription/useTranscriptionWithRetry.ts
+++ b/src/features/transcription/useTranscriptionWithRetry.ts
@@ -35,6 +35,7 @@ export function useTranscriptionWithRetry() {
         // Log the internal error for debugging (local console/storage)
         try { console.error('transcribeAudio error:', err); } catch (_) {}
 
+        // Keep loading true while retrying; update attempts and a friendly error message for the UI
         setState({ loading: true, attempts, result: null, error: userMsg });
 
         if (attempts >= maxAttempts) {


### PR DESCRIPTION
Working as asimov + artist

Adds user-facing error banner and a transcription hook with retry logic (3 attempts). Includes tests that simulate transient and permanent failures.

Closes #15

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
